### PR TITLE
fix: warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gitignore
 interpretador
 *.o
+.vscode

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ virtualmachine.o: virtualmachine.c virtualmachine.h
 
 clean:
 	rm -f *.o
-	rm $(TARGET)
+	rm -f $(TARGET)
 
 clear:
 	rm -f *.o

--- a/virtualmachine.c
+++ b/virtualmachine.c
@@ -460,7 +460,7 @@ char *interpretaStr(char *str)
     int indice = 0;
     for (int i = 0; i < len; i++)
     {
-        if ((str[i] == '\\'))
+        if (str[i] == '\\')
             switch (str[i + 1])
             {
             case 'n':

--- a/virtualmachine.h
+++ b/virtualmachine.h
@@ -41,7 +41,7 @@ extern t_variable *listVariables;
 unsigned int lenVarambiente;
 t_varambiente *listVarambiente;
 
-void exec();
+void exec(Quad *lista);
 void add_var(char *id, double value, byte type);
 float getValue(char *lexema);
 Quad *copyQuad(Quad *list);


### PR DESCRIPTION
```
./virtualmachine.h:44:6: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
   44 | void exec();
      |      ^
virtualmachine.c:122:6: note: conflicting prototype is here
  122 | void exec(Quad *lista)
      |      ^
virtualmachine.c:463:21: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
  463 |         if ((str[i] == '\\'))
      |              ~~~~~~~^~~~~~~
virtualmachine.c:463:21: note: remove extraneous parentheses around the comparison to silence this warning
  463 |         if ((str[i] == '\\'))
      |             ~       ^      ~
virtualmachine.c:463:21: note: use '=' to turn this equality comparison into an assignment
  463 |         if ((str[i] == '\\'))
```